### PR TITLE
fixed edit partner submit button to save changes

### DIFF
--- a/app_project/jsx_files/modalmenu.jsx
+++ b/app_project/jsx_files/modalmenu.jsx
@@ -62,17 +62,17 @@ class ModalMenu extends React.Component {
       const result = window.confirm(`Are you sure you want to edit partner ${this.state.prev_data.org_name}?`);
       if (!result) {
         this.close_menu();
+        return;
       }
-    } else {
-      $("#save-btn").prop("disabled", true);
-      if (this.state.submit_form_handler) {
-        var data = this.get_data();
+    }
+    $("#save-btn").prop("disabled", true);
+    if (this.state.submit_form_handler) {
+      var data = this.get_data();
         
-        this.state.submit_form_handler(
-          data, this.close_menu, this.state.handle_data_callback);
-      } else {
-        this.close_menu();
-      }
+      this.state.submit_form_handler(
+        data, this.close_menu, this.state.handle_data_callback);
+    } else {
+      this.close_menu();
     }
   }
 

--- a/public/javascripts/app_project/modalmenu.js
+++ b/public/javascripts/app_project/modalmenu.js
@@ -88,16 +88,16 @@ var ModalMenu = function (_React$Component) {
         var result = window.confirm("Are you sure you want to edit partner " + _this.state.prev_data.org_name + "?");
         if (!result) {
           _this.close_menu();
+          return;
         }
-      } else {
-        $("#save-btn").prop("disabled", true);
-        if (_this.state.submit_form_handler) {
-          var data = _this.get_data();
+      }
+      $("#save-btn").prop("disabled", true);
+      if (_this.state.submit_form_handler) {
+        var data = _this.get_data();
 
-          _this.state.submit_form_handler(data, _this.close_menu, _this.state.handle_data_callback);
-        } else {
-          _this.close_menu();
-        }
+        _this.state.submit_form_handler(data, _this.close_menu, _this.state.handle_data_callback);
+      } else {
+        _this.close_menu();
       }
     };
 


### PR DESCRIPTION
Editing partners is fixed, but adding new partners is still broken.  Adding partners still creates a new blank partner, which you can now edit later as a workaround.